### PR TITLE
Add optional verbose event logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,21 @@ end
 
 Note that custom events are only currenly reported by the CSV collector.
 
+#### Custom Event Recording
+
+It is possible to record the event metadata for a spec.
+
+```Ruby
+  describe 'Records all active record queries', record_events: %w[sql.active_record] do
+    it 'Records Rails deprecations', record_events: %w[deprecation.rails] do
+      ...
+    end
+    it 'Records nothing' do
+      ...
+    end
+  end
+```
+
 ### Choose a results collector
 
 Results are collected just by running the specs.

--- a/lib/rspec_profiling/collectors/csv.rb
+++ b/lib/rspec_profiling/collectors/csv.rb
@@ -61,13 +61,13 @@ module RspecProfiling
 
       def event_headers
         config.events.flat_map do |event|
-          ["#{event}_count", "#{event}_time"]
+          ["#{event}_count", "#{event}_time", "#{event}_events"]
         end
       end
 
       def event_cells(attributes)
         config.events.flat_map do |event|
-          [attributes[:event_counts][event], attributes[:event_times][event]]
+          [attributes[:event_counts][event], attributes[:event_times][event], attributes[:event_events][event]]
         end
       end
     end

--- a/lib/rspec_profiling/run.rb
+++ b/lib/rspec_profiling/run.rb
@@ -45,7 +45,8 @@ module RspecProfiling
         request_time:  @current_example.request_time,
         events:        @events,
         event_counts:  @current_example.event_counts,
-        event_times:   @current_example.event_times
+        event_times:   @current_example.event_times,
+        event_events:   @current_example.event_events
       })
     end
 
@@ -69,9 +70,9 @@ module RspecProfiling
     end
 
     def start_counting_events
-      events.each do |event|
-        ActiveSupport::Notifications.subscribe(event) do |extra, start, finish, id, request|
-          @current_example.try(:log_event, event, start, finish)
+      events.each do |event_name|
+        ActiveSupport::Notifications.subscribe(event_name) do |name, start, finish, id, event|
+          @current_example.try(:log_event, event_name, event, start, finish)
         end
       end
     end

--- a/spec/run_spec.rb
+++ b/spec/run_spec.rb
@@ -1,3 +1,4 @@
+require "active_support"
 require "active_support/core_ext"
 require "rspec_profiling/run"
 require "time"
@@ -18,7 +19,7 @@ module RspecProfiling
     end
 
     def simulate_event(name)
-      ActiveSupport::Notifications.instrument(name, name, 100, 150, 3, {})
+      ActiveSupport::Notifications.instrument(name, name, 100, 150, 3, {name: 'custom', data: {key: 'value'}})
     end
 
     describe "#run_example" do
@@ -30,7 +31,8 @@ module RspecProfiling
         ExampleDouble.new({
           file_path: "/something_spec.rb",
           line_number: 15,
-          full_description: "should do something"
+          full_description: "should do something",
+          record_events: %w[custom]
         })
       end
 
@@ -100,6 +102,10 @@ module RspecProfiling
 
       it "records the custom event time" do
         expect(result.event_times["custom"]).to eq 50
+      end
+
+      it "records the custom event events" do
+        expect(result.event_events["custom"]).to eq [{"data"=>{"key"=>"value"}, "name"=>"custom"}]
       end
     end
 


### PR DESCRIPTION
Allowing for optional verbose logging of tracked events. There is the possibility of some events not being serializable by default (factory_bot for instance). I expect to add the ability to create custom serializers for events in the future.

```Ruby
  describe 'Records all active record queries', record_events: %w[sql.active_record] do
    it 'Records Rails deprecations', record_events: %w[deprecation.rails] do
      ...
    end
    it 'Records nothing' do
      ...
    end
  end
```