### PR TITLE
removing dependencies on sqlite and pg if you are not using them

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ which results will be collected.
 bundle exec rake rspec_profiling:install
 ```
 
+If you are planning on using `sqlite` or `pg` ensure to add the depency to your gemfile
+
+```
+  gem 'sqlite', require: false
+  gem 'pg', require: false
+```
+
 ## Usage
 
 ### Choose a version control system
@@ -105,8 +112,15 @@ Results are collected just by running the specs.
 
 #### SQLite3
 
-By default, profiles are collected in an SQL database. Make sure you've
-run the installation rake task before attempting.
+Make sure you've run the installation rake task before attempting.
+
+You can configure `RspecProfiling` to collect results in a SQL database in `config/initializers/rspec_profiling.rb`:
+
+```Ruby
+RspecProfiling.configure do |config|
+  config.collector = RspecProfiling::Collectors::SQL
+end
+```
 
 You can review results by running the RspecProfiling console.
 The console has a preloaded `results` variable.
@@ -137,7 +151,7 @@ debugging, such as `exception` and `status`.
 
 #### CSV
 
-You can configure `RspecProfiling` to collect results in a CSV in `config/initializers/rspec_profiling.rb`:
+By default, profiles are collected in an a CSV file. You can configure `RspecProfiling` to collect results in a CSV in `config/initializers/rspec_profiling.rb`:
 
 ```Ruby
 RspecProfiling.configure do |config|

--- a/lib/rspec_profiling.rb
+++ b/lib/rspec_profiling.rb
@@ -4,11 +4,23 @@ require "rspec_profiling/config"
 require "rspec_profiling/version"
 require "rspec_profiling/run"
 require "rspec_profiling/collectors/csv"
-require "rspec_profiling/collectors/sql"
-require "rspec_profiling/collectors/psql"
 require "rspec_profiling/vcs/git"
 require "rspec_profiling/vcs/svn"
 require "rspec_profiling/vcs/git_svn"
+
+begin
+  require "rspec_profiling/collectors/sql"
+rescue LoadError
+  #no op
+end
+
+begin
+  require "rspec_profiling/collectors/psql"
+rescue LoadError
+  #no op
+end
+
+
 
 module RspecProfiling
   class Railtie < Rails::Railtie

--- a/lib/rspec_profiling/collectors/psql.rb
+++ b/lib/rspec_profiling/collectors/psql.rb
@@ -47,7 +47,7 @@ module RspecProfiling
       end
 
       def insert(attributes)
-        results.create!(attributes.except(:created_at))
+        results.create!(attributes.except(:created_at, :events, :event_counts, :event_times, :event_events))
       end
 
       def results

--- a/lib/rspec_profiling/collectors/sql.rb
+++ b/lib/rspec_profiling/collectors/sql.rb
@@ -47,7 +47,7 @@ module RspecProfiling
       end
 
       def insert(attributes)
-        results.create!(attributes.except(:created_at))
+        results.create!(attributes.except(:created_at, :events, :event_counts, :event_times, :event_events))
       end
 
       def results

--- a/lib/rspec_profiling/config.rb
+++ b/lib/rspec_profiling/config.rb
@@ -5,7 +5,7 @@ module RspecProfiling
 
   def self.config
     @config ||= OpenStruct.new({
-      collector:  RspecProfiling::Collectors::SQL,
+      collector:  RspecProfiling::Collectors::CSV,
       vcs:        RspecProfiling::VCS::Git,
       table_name: 'spec_profiling_results',
       events:     []

--- a/lib/rspec_profiling/run.rb
+++ b/lib/rspec_profiling/run.rb
@@ -2,8 +2,6 @@ require "rspec_profiling/example"
 require "rspec_profiling/vcs/git"
 require "rspec_profiling/vcs/svn"
 require "rspec_profiling/vcs/git_svn"
-require "rspec_profiling/collectors/sql"
-require "rspec_profiling/collectors/psql"
 require "rspec_profiling/collectors/csv"
 
 module RspecProfiling

--- a/rspec_profiling.gemspec
+++ b/rspec_profiling.gemspec
@@ -18,9 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sqlite3"
   spec.add_dependency "activerecord"
-  spec.add_dependency "pg"
   spec.add_dependency "rails"
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
This removes the dependency for the `sqlite3` and `pg` gems if you are not using them.